### PR TITLE
fix dependencies in Flutter SDK v2.x

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   font_awesome_flutter: ^8.0.1
   firebase_messaging: ^2.0.0
   share: ^0.5.3
+  http: ^0.12.2
 
 dev_dependencies:
   flutter_test:
@@ -20,8 +21,8 @@ dev_dependencies:
   flutter_launcher_icons: "^0.6.0"
   build_runner: ^0.9.0
   json_serializable: ^0.5.4
-  mockito: ^3.0.0
-  
+  mockito: ^4.0.0
+
 flutter_icons:
   android: true
   ios: true


### PR DESCRIPTION
```bash
$ flutter pub get
$ flutter run
```

## lockfile problem

```bash
$ flutter pub get
$ tail pubspec.lock

sdks:
  dart: "<empty>"
  flutter: ">=0.1.4 <2.0.0"
```

dart: It is strange that "<empty>" is recorded.

## does not work tests 

```bash
$ flutter test

Compiler message:                                                                                                                                                                                             
Error: Could not resolve the package 'test' in 'package:test/test.dart'.                               
repository/cache_repository_test.dart:10:8: Error: Not found: 'package:test/test.dart'                                                                                                                        
import 'package:test/test.dart';                                                                                                                                                                              
       ^                                                                                               
repository/cache_repository_test.dart:26:7: Error: Method not found: 'expect'.                                                                                                                                
      expect(list.length, 1);                                                                          
      ^^^^^^                                                                                                                                                                                                  
repository/cache_repository_test.dart:14:5: Error: Method not found: 'test'.                                                                                                                                  
    test('returns cached list when cache is not empty', () async {                                                                                                                                            
    ^^^^                                                                                                                                                                                                      
repository/cache_repository_test.dart:43:7: Error: Method not found: 'expect'.                         
      expect(list.length, 1);                                                                                                                                                                                 
      ^^^^^^ 
```